### PR TITLE
Disallow webcrawler to crawl images

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: Googlebot-Image
+Disallow: /assets


### PR DESCRIPTION
Changes proposed in this pull request:
- Add robots.txt to disallow images

Connected to #30.
